### PR TITLE
PRO-16379: Parse id from branch and accept lower case in project name

### DIFF
--- a/src/helpers/__tests__/issue.spec.ts
+++ b/src/helpers/__tests__/issue.spec.ts
@@ -17,7 +17,7 @@ describe('extractIssueNumbers function', () => {
 
   it('should extract issue numbers when surrounded by non-alphanumeric characters', () => {
     const input = 'Issue: (ABC-789), Dash-123, Colon:XYZ-456';
-    const expectedOutput = ['ABC-789', 'XYZ-456'];
+    const expectedOutput = ['ABC-789', 'DASH-123', 'XYZ-456'];
 
     expect(extractIssueNumbers(input)).toEqual(expectedOutput);
   });

--- a/src/helpers/github.ts
+++ b/src/helpers/github.ts
@@ -61,6 +61,10 @@ export async function getPullRequestIssueIds(pr: PullRequestType): Promise<strin
     extractIssueNumbers(pr.title).map((id) => ids.add(id));
   }
 
+  if (typeof pr.head?.ref === 'string') {
+    extractIssueNumbers(pr.head.ref).map((id) => ids.add(id));
+  }
+
   return [...ids];
 }
 

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -1,7 +1,7 @@
-const ISSUE_PATTERN_RE = /(?<![a-zA-Z0-9])[A-Z][A-Z0-9]{1,}-\d+(?![a-zA-Z0-9])/g;
+const ISSUE_PATTERN_RE = /(?<![a-zA-Z0-9])[A-Z][A-Z0-9]{1,}-\d+(?![a-zA-Z0-9])/gi;
 
 export function extractIssueNumbers(string: string): string[] {
   const result: Set<string> = new Set();
-  string.match(ISSUE_PATTERN_RE)?.forEach((issue) => result.add(issue));
+  string.match(ISSUE_PATTERN_RE)?.forEach((issue) => result.add(issue.toUpperCase()));
   return [...result];
 }


### PR DESCRIPTION
Added parsing of the Jira ID from the branch name, not only from the PR title:
```
 if (typeof pr.head?.ref === 'string') {
    extractIssueNumbers(pr.head.ref).map((id) => ids.add(id));
  }
```

`const ISSUE_PATTERN_RE = /(?<![a-zA-Z0-9])[A-Z][A-Z0-9]{1,}-\d+(?![a-zA-Z0-9])/gi;`
_i_  (case-insensitive) - added to support Branch and PR names in lower case


`result.add(issue.toUpperCase()));`
_issue.toUpperCase_ - required to avoid accidentally getting duplicates from the same number with different letter casing